### PR TITLE
Blob issue test case

### DIFF
--- a/flink-runtime/src/test/java/org/apache/flink/runtime/execution/librarycache/BlobLibraryCacheManagerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/execution/librarycache/BlobLibraryCacheManagerTest.java
@@ -80,54 +80,57 @@ public class BlobLibraryCacheManagerTest extends TestLogger {
     public void testLibraryCacheBlobIssue() throws Exception {
 
         JobID jobID = new JobID();
+
         BlobServer server = null;
         PermanentBlobCache cache = null;
         BlobLibraryCacheManager libCache = null;
 
-        final byte[] jar = new byte[128];
+        final byte[] jarContents = new byte[128];
 
         try {
             Configuration config = new Configuration();
+            // Default cache clean up interval (library-cache-manager.cleanup.interval) is 1 hour.
+            // Considering if reducing this considerable (like to 1 sec) would help.
             config.set(BlobServerOptions.CLEANUP_INTERVAL, 1L);
 
             server = new BlobServer(config, temporaryFolder.newFolder(), new VoidBlobStore());
             server.start();
+
             InetSocketAddress serverAddress = new InetSocketAddress("localhost", server.getPort());
             cache = new PermanentBlobCache(config, temporaryFolder.newFolder(), new VoidBlobStore(), serverAddress);
 
             // Initial Job submission
-            List<PermanentBlobKey> keys = new ArrayList<>();
-            keys.add(server.putPermanent(jobID, jar));
+            List<PermanentBlobKey> jarKeys = new ArrayList<>(1);
+            jarKeys.add(server.putPermanent(jobID, jarContents));
 
             libCache = createBlobLibraryCacheManager(cache);
             cache.registerJob(jobID);
 
             final LibraryCacheManager.ClassLoaderLease classLoaderLease = libCache.registerClassLoaderLease(jobID);
-            final UserCodeClassLoader classLoader = classLoaderLease.getOrResolveClassLoader(keys, Collections.emptyList());
+            final UserCodeClassLoader classLoader = classLoaderLease.getOrResolveClassLoader(jarKeys, Collections.emptyList());
+            // Task uses classLoader to load the job's code
 
-            // Lease is NOT released
+            /* Lease is NOT released, either because:
+                - Tasks fail to call release() on the lease OR
+                - The reference count on the lease is imbalanced (more calls to "obtain" than to "release" the lease)
+            */
             // classLoaderLease.release();
 
             // Resubmission (same Job id and jar(s))
-            List<PermanentBlobKey> keys2 = new ArrayList<>();
-            keys2.add(server.putPermanent(jobID, jar));
+            List<PermanentBlobKey> newJarKeys = new ArrayList<>();
+            newJarKeys.add(server.putPermanent(jobID, jarContents));
 
             // Task requests class loader, fails because the cache contains an entry for the same job id but with different jar keys
             final LibraryCacheManager finalLibCache = libCache;
             assertThrows(IllegalStateException.class, () -> {
                 finalLibCache
                         .registerClassLoaderLease(jobID)
-                        .getOrResolveClassLoader(keys2, Collections.emptyList());
+                        .getOrResolveClassLoader(newJarKeys, Collections.emptyList());
             });
 
         } finally {
             if (libCache != null) {
                 libCache.shutdown();
-            }
-
-            // should have been closed by the libraryCacheManager, but just in case
-            if (cache != null) {
-                cache.close();
             }
 
             if (server != null) {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/execution/librarycache/BlobLibraryCacheManagerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/execution/librarycache/BlobLibraryCacheManagerTest.java
@@ -58,6 +58,7 @@ import static org.hamcrest.Matchers.sameInstance;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.junit.Assume.assumeTrue;
@@ -74,6 +75,66 @@ public class BlobLibraryCacheManagerTest extends TestLogger {
     }
 
     @Parameterized.Parameter public boolean wrapsSystemClassLoader;
+
+    @Test
+    public void testLibraryCacheBlobIssue() throws Exception {
+
+        JobID jobID = new JobID();
+        BlobServer server = null;
+        PermanentBlobCache cache = null;
+        BlobLibraryCacheManager libCache = null;
+
+        final byte[] jar = new byte[128];
+
+        try {
+            Configuration config = new Configuration();
+            config.set(BlobServerOptions.CLEANUP_INTERVAL, 1L);
+
+            server = new BlobServer(config, temporaryFolder.newFolder(), new VoidBlobStore());
+            server.start();
+            InetSocketAddress serverAddress = new InetSocketAddress("localhost", server.getPort());
+            cache = new PermanentBlobCache(config, temporaryFolder.newFolder(), new VoidBlobStore(), serverAddress);
+
+            // Initial Job submission
+            List<PermanentBlobKey> keys = new ArrayList<>();
+            keys.add(server.putPermanent(jobID, jar));
+
+            libCache = createBlobLibraryCacheManager(cache);
+            cache.registerJob(jobID);
+
+            final LibraryCacheManager.ClassLoaderLease classLoaderLease = libCache.registerClassLoaderLease(jobID);
+            final UserCodeClassLoader classLoader = classLoaderLease.getOrResolveClassLoader(keys, Collections.emptyList());
+
+            // Lease is NOT released
+            // classLoaderLease.release();
+
+            // Resubmission (same Job id and jar(s))
+            List<PermanentBlobKey> keys2 = new ArrayList<>();
+            keys2.add(server.putPermanent(jobID, jar));
+
+            // Task requests class loader, fails because the cache contains an entry for the same job id but with different jar keys
+            final LibraryCacheManager finalLibCache = libCache;
+            assertThrows(IllegalStateException.class, () -> {
+                finalLibCache
+                        .registerClassLoaderLease(jobID)
+                        .getOrResolveClassLoader(keys2, Collections.emptyList());
+            });
+
+        } finally {
+            if (libCache != null) {
+                libCache.shutdown();
+            }
+
+            // should have been closed by the libraryCacheManager, but just in case
+            if (cache != null) {
+                cache.close();
+            }
+
+            if (server != null) {
+                server.close();
+            }
+        }
+    }
 
     /**
      * Tests that the {@link BlobLibraryCacheManager} cleans up after the class loader leases for


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

*(For example: This pull request makes task deployment go through the blob server, rather than through RPC. That way we avoid re-transferring them on each deployment (during recovery).)*


## Brief change log

*(for example:)*
  - *The TaskInfo is stored in the blob store on job creation time as a persistent artifact*
  - *Deployments RPC transmits only the blob storage reference*
  - *TaskManagers retrieve the TaskInfo from the blob cache*


## Verifying this change

Please make sure both new and modified tests in this PR follow [the conventions for tests defined in our code quality guide](https://flink.apache.org/how-to-contribute/code-style-and-quality-common/#7-testing).

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (100MB)*
  - *Extended integration test for recovery after master (JobManager) failure*
  - *Added test that validates that TaskInfo is transferred only once across recoveries*
  - *Manually verified the change by running a 4 node cluster with 2 JobManagers and 4 TaskManagers, a stateful streaming program, and killing one JobManager and two TaskManagers during the execution, verifying that recovery happens correctly.*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / no)
  - The serializers: (yes / no / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / no / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / no / don't know)
  - The S3 file system connector: (yes / no / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
